### PR TITLE
Add parameter to rm to permit removal of build directory during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ ifeq ($(OS), Windows_NT) # windows
 	K5PROG = utils/k5prog/k5prog.exe -D -F -YYY -p /dev/com3 -b
 else
 	MKDIR = mkdir -p $(1)
-	RM = rm -f
+	RM = rm -rf
 	FixPath = $1
 	WHERE = which
 	DEL = del


### PR DESCRIPTION
Current Makefile doesn't accommodate build directory `_build` because `rm` on Linux/MacOS doesn't support removing directories without `-r` parameter.