### PR TITLE
Fix a typo in the build script

### DIFF
--- a/compile-with-docker.bat
+++ b/compile-with-docker.bat
@@ -1,4 +1,4 @@
 @echo off
 docker build -t uvk5 .
-docker run --rm -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make clean && make && cp firmware* compiled-firmware/"
+docker run --rm -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make clean && make && cp firmware/* compiled-firmware/"
 pause

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 docker build -t uvk5 .
-docker run --rm -v ${PWD}/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"
+docker run --rm -v ${PWD}/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware/* compiled-firmware/"


### PR DESCRIPTION
The code `cp firmware* compiled-firmware/` attempts to copy the directory "firmware" to the directory "compiled-firmware" but the recursive flag is not specified. So instead I changed it to copy the contents of the directory to the other directory.